### PR TITLE
Ignore CSS files in plugins [minor]

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,17 @@
+name: Autotag and Release
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  tag-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pantheon-systems/action-autotag@v0
+        with:
+          gh-token: ${{ github.token }}

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ runs:
         # check if we're running a plugin or theme
         if [ "${{ inputs.type }}" = "plugin" ]; then
           echo "Running WP.org Code Analysis on a plugin..."
-          vendor/bin/phpcs -s --standard=MinimalPluginStandard --ignore=wporg-code-analysis/* $path
+          vendor/bin/phpcs -s --standard=MinimalPluginStandard --ignore=wporg-code-analysis/*,*\/*.css $path
         elif [ "${{ inputs.type }}" = "theme" ]; then
           echo "Running WP.org Code Analysis on a theme..."
           vendor/bin/phpcs -s --standard=MinimalThemeStandard --ignore=wporg-code-analysis/*,*\/*.css $path


### PR DESCRIPTION
We're already ignoring in Themes. This applies the same rule to plugins.

When left at the previous value, a warning is thrown when the validator runs that a non-minified css file is required when a minified css file is detected. Unfortunately, even if a non-minified css file exists, the warning is still thrown and the test is failed.

This also adds autotagging so we don't need to manually push out updates.